### PR TITLE
Fix boolean and empty string value handling

### DIFF
--- a/src/core/option-resolvers.ts
+++ b/src/core/option-resolvers.ts
@@ -41,7 +41,10 @@ export function resolveBaseOption(key: string, value: string | boolean | number)
         throw new Error("Invalid type for key. Only string, and number are accepted");
     }
     if (typeof value === 'boolean') {
-        return `// @${key.toString().trim()}`
+        return value ? `// @${key.toString().trim()}` : ``
+    }
+    if (typeof value === 'string' && !value) {
+        return ``
     }
     return `// @${key.toString().trim()}\t${value.toString().trim()}`
 }


### PR DESCRIPTION
Previously if a value was of type boolean, then the header entry would be added regardless of the boolean value (such that false would still get included).

Values of empty string would result in the header entry being output with no second argument. It makes more sense to skip the entry if the second half of the pair is empty.